### PR TITLE
chore: bump Node 20 actions off the deprecation path

### DIFF
--- a/.github/workflows/changesets-from-conventional-commits.yml
+++ b/.github/workflows/changesets-from-conventional-commits.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'portabletext'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.ECOSCRIPT_APP_ID }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.ECOSCRIPT_APP_ID }}
@@ -55,7 +55,7 @@ jobs:
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           cache: pnpm

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           cache: pnpm
@@ -29,7 +29,7 @@ jobs:
       - run: pnpm install
       - run: pnpm format
       - run: git restore .github/workflows pnpm-lock.yaml
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.ECOSCRIPT_APP_ID }}


### PR DESCRIPTION
`actions/create-github-app-token@v2` and `pnpm/action-setup@v4` run on Node 20, which GitHub has deprecated. Runners now force them onto Node 24 and emit a warning on every run, surfaced in the editor repo's "Add changeset to Renovate updates" job, which calls these reusable workflows:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/create-github-app-token@v2

This bumps `actions/create-github-app-token` v2 → v3 (all three workflows) and `pnpm/action-setup` v4 → v6 (`changesets.yml`, `format.yml`). `actions/checkout@v6` and `actions/setup-node@v6` already target Node 24, so they're left as-is. Workflow-only change.