### PR TITLE
fix(ci): pin the changesets release job to Node 22

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -59,7 +59,13 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: lts/*
+          # Pinned to 22, not lts/* (now 24): changesets' changelog generator
+          # (@changesets/changelog-github -> @changesets/get-github-info ->
+          # node-fetch@2) throws ERR_STREAM_PREMATURE_CLOSE decompressing
+          # GitHub's gzip'd GraphQL response on Node 24, failing `changeset
+          # version`. node-fetch@2 is reliable on Node 22. Revert to lts/*
+          # once changesets drops node-fetch@2.
+          node-version: 22
         # temporary until setup-node action comes with npm version that contains oidc setup by default
       - name: Update npm to use trusted publishing (OIDC)
         run: npm install -g npm@latest


### PR DESCRIPTION
`changeset version` has been failing on the release runner with `ERR_STREAM_PREMATURE_CLOSE` while generating changelog entries:

```
The following error was encountered while generating changelog entries
🦋  error FetchError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
   ... node-fetch@2.7.0, on Node 24.17.0
```

The changelog generator chain is `@changesets/changelog-github` → `@changesets/get-github-info` → `node-fetch@2`, and `node-fetch@2` can't decompress GitHub's gzip'd GraphQL response on **Node 24**, which `lts/*` now resolves to.

Diagnosis: the *same* `changeset version`, same changeset batch, same dependency versions, **succeeds on Node 22/23 locally** and failed only on the Node 24 runner, and reruns failed deterministically. So it's neither a code regression nor a GitHub transient, it's the runner's Node version.

This pins the changesets job to **Node 22** (where node-fetch@2 is reliable) instead of `lts/*`. Node 22 is a fine publish runtime, every consumer's `engines` allows it (`sanity` is `>=22.12`). The pin is documented inline and should be reverted to `lts/*` once changesets drops node-fetch@2 (its newer `get-github-info` still pulls node-fetch@2, so not imminent).

Affects every repo that releases through this reusable workflow.
