### PR TITLE
chore(ci): use create-github-app-token `client-id` instead of deprecated `app-id`

### DIFF
--- a/.github/workflows/changesets-from-conventional-commits.yml
+++ b/.github/workflows/changesets-from-conventional-commits.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.ECOSCRIPT_APP_ID }}
+          client-id: ${{ vars.ECOSCRIPT_CLIENT_ID }}
           private-key: ${{ secrets.ECOSCRIPT_APP_PRIVATE_KEY }}
       - uses: mscharley/dependency-changesets-action@f96232368519695969bea8a8cfff7cca32b1e56a # v1.2.4
         with:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.ECOSCRIPT_APP_ID }}
+          client-id: ${{ vars.ECOSCRIPT_CLIENT_ID }}
           private-key: ${{ secrets.ECOSCRIPT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.ECOSCRIPT_APP_ID }}
+          client-id: ${{ vars.ECOSCRIPT_CLIENT_ID }}
           private-key: ${{ secrets.ECOSCRIPT_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:


### PR DESCRIPTION
`actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`, so every token mint logs:

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

across the release (`changesets.yml`), renovate-changeset (`changesets-from-conventional-commits.yml`), and format (`format.yml`) workflows.

This switches all three to `client-id`, reading the ecoscript app's client id from the org-level `ECOSCRIPT_CLIENT_ID` Actions variable (per review) so the same fix applies across the PT repos that use these reusable workflows. The private key (`ECOSCRIPT_APP_PRIVATE_KEY`) remains the only secret. The `ECOSCRIPT_APP_ID` secret reference is dropped (nothing reads it after this).

Workflow-only; affects every repo releasing through these reusable workflows.
