### PR TITLE
chore(ci): unpin the changesets job from Node 22

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -59,13 +59,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: pnpm
-          # Pinned to 22, not lts/* (now 24): changesets' changelog generator
-          # (@changesets/changelog-github -> @changesets/get-github-info ->
-          # node-fetch@2) throws ERR_STREAM_PREMATURE_CLOSE decompressing
-          # GitHub's gzip'd GraphQL response on Node 24, failing `changeset
-          # version`. node-fetch@2 is reliable on Node 22. Revert to lts/*
-          # once changesets drops node-fetch@2.
-          node-version: 22
+          node-version: lts/*
         # temporary until setup-node action comes with npm version that contains oidc setup by default
       - name: Update npm to use trusted publishing (OIDC)
         run: npm install -g npm@latest


### PR DESCRIPTION
Reverts the `node-version: 22` pin (#16) on the changesets release job, restoring `lts/*`.

The pin was a misdiagnosis. The `ERR_STREAM_PREMATURE_CLOSE` failure in `changeset version` (changelog generation through `@changesets/changelog-github` → `@changesets/get-github-info` → `node-fetch@2`) is **not** Node-24-specific: a Node security release, the *"fix response queue poisoning in `http.Agent`"* change, shipped across every maintained line, 22.23.0 included, and altered keep-alive socket-reuse timing so `node-fetch@2`'s chunked-transfer end detector raises a false-positive premature close on a cleanly completed gzipped response.

References: node-fetch#1767, nodejs/node#63989, changesets#2115. The failing editor run that prompted this was itself on Node 22.23.0, so the pin fixed nothing.

The real fix lives per repo: `pnpm patch node-fetch@2` to guard the error with `!response.complete` (the behavior `node-fetch@3` already has), e.g. portabletext/editor#2869. With that patch in place the Node version is irrelevant, so there's no reason to hold the job off `lts/*`.

Note: this revert doesn't make releases pass on its own, the per-repo `node-fetch` patch is what does that. It just removes a no-op pin (and its now-inaccurate "node-fetch@2 is reliable on Node 22" comment) so the job tracks `lts/*` again.
