### PR TITLE
fix(ci): pull the latest LTS Node in the changesets job

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: pnpm
+          check-latest: true
           node-version: lts/*
         # temporary until setup-node action comes with npm version that contains oidc setup by default
       - name: Update npm to use trusted publishing (OIDC)


### PR DESCRIPTION
Adopts the `check-latest: true` workaround (matching sanity-io/.github@870e21b) for the changesets release job.

`changeset version` fails on the release runner with `ERR_STREAM_PREMATURE_CLOSE` during changelog generation: `@changesets/changelog-github` → `@changesets/get-github-info` queries the GitHub GraphQL API through `node-fetch@2`, and a Node security release (the *"fix response queue poisoning in `http.Agent`"* change, shipped across every maintained line, 24.17.0 and 22.23.0 included) changed keep-alive socket-reuse timing so `node-fetch@2` raises a false-positive premature close on a cleanly completed gzipped response.

References: node-fetch#1767, nodejs/node#63989, changesets#2115.

The fix landed upstream in **24.18.0** (and **22.23.1**), both released after the issue closed. But the Actions runner's tool cache can still serve the regressed patch, so `lts/*` alone may resolve to a broken Node. `check-latest: true` makes `actions/setup-node` fetch the newest matching version from nodejs.org, so the job runs on a patch that carries the fix.

This supersedes the per-repo `node-fetch` patch approach (portabletext/editor#2869): it's workflow-only, fixes every PT repo releasing through this shared workflow at once, and touches no lockfile, so it has no Vercel/`pnpm install` blast radius. Once this is in and a release proves green, that patch PR can be closed.
