### PR TITLE
fix: pin npm 11 in the changesets publish step

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -63,7 +63,9 @@ jobs:
           node-version: lts/*
         # temporary until setup-node action comes with npm version that contains oidc setup by default
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        # Pinned to npm 11: npm 12 fails to publish with provenance
+        # (`Cannot find module 'sigstore'` in `libnpmpublish/provenance.js`)
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
The editor repo's Version Packages release (portabletext/editor#2960's merge, run 29011799838) failed to publish every package with `Cannot find module 'sigstore'` from `libnpmpublish/lib/provenance.js`, deterministically across reruns.

The publish step installs `npm@latest`, which started resolving to npm 12 (released this week). npm 12's provenance path requires `sigstore` but no longer bundles it, so `NPM_CONFIG_PROVENANCE: true` sends every publish into the missing module.

Pinning `npm@11`, the last major that publishes with provenance, until npm 12's provenance path works. One-line change plus a comment carrying the reason.
